### PR TITLE
fix: remove required fields, where exact key cannot be determined

### DIFF
--- a/example-artifacts/fsh-generated/data/fsh-index.json
+++ b/example-artifacts/fsh-generated/data/fsh-index.json
@@ -13,7 +13,7 @@
     "fshType": "Instance",
     "fshFile": "ExampleCapabilityStatementSMART.fsh",
     "startLine": 1,
-    "endLine": 99
+    "endLine": 104
   },
   {
     "outputFile": "OperationDefinition-ExampleOperationModeOperationDefinition.json",
@@ -54,6 +54,14 @@
     "fshFile": "ExamplePatient.fsh",
     "startLine": 20,
     "endLine": 27
+  },
+  {
+    "outputFile": "StructureDefinition-ExampleObservationProfile.json",
+    "fshName": "ExampleObservationProfile",
+    "fshType": "Profile",
+    "fshFile": "ExampleObservation.fsh",
+    "startLine": 1,
+    "endLine": 4
   },
   {
     "outputFile": "StructureDefinition-example-encounter.json",

--- a/example-artifacts/fsh-generated/fsh-index.txt
+++ b/example-artifacts/fsh-generated/fsh-index.txt
@@ -1,11 +1,12 @@
 Output File                                                       Name                                     Type      FSH File                             Lines
 CapabilityStatement-ExampleCapabilityStatementOauth.json          ExampleCapabilityStatementOauth          Instance  ExampleCapabilityStatementOAuth.fsh  1 - 86
-CapabilityStatement-ExampleCapabilityStatementSMART.json          ExampleCapabilityStatementSMART          Instance  ExampleCapabilityStatementSMART.fsh  1 - 99
+CapabilityStatement-ExampleCapabilityStatementSMART.json          ExampleCapabilityStatementSMART          Instance  ExampleCapabilityStatementSMART.fsh  1 - 104
 OperationDefinition-ExampleOperationModeOperationDefinition.json  ExampleOperationModeOperationDefinition  Instance  ExampleOperationDefinitions.fsh      88 - 127
 OperationDefinition-ExampleQueryInstanceOperationDefinition.json  ExampleQueryInstanceOperationDefinition  Instance  ExampleOperationDefinitions.fsh      44 - 85
 OperationDefinition-ExampleQueryOperationDefinition.json          ExampleQueryOperationDefinition          Instance  ExampleOperationDefinitions.fsh      1 - 42
 OperationDefinition-ExampleSystemOperationDefinition.json         ExampleSystemOperationDefinition         Instance  ExampleOperationDefinitions.fsh      129 - 170
 Patient-example-patient-instance.json                             ExamplePatientInstance                   Instance  ExamplePatient.fsh                   20 - 27
+StructureDefinition-ExampleObservationProfile.json                ExampleObservationProfile                Profile   ExampleObservation.fsh               1 - 4
 StructureDefinition-example-encounter.json                        ExampleEncounterProfile                  Profile   ExampleEncounter.fsh                 1 - 6
 StructureDefinition-example-patient-2.json                        ExamplePatientProfile2                   Profile   ExamplePatient.fsh                   13 - 18
 StructureDefinition-example-patient.json                          ExamplePatientProfile                    Profile   ExamplePatient.fsh                   1 - 11

--- a/example-artifacts/fsh-generated/includes/fsh-link-references.md
+++ b/example-artifacts/fsh-generated/includes/fsh-link-references.md
@@ -3,6 +3,7 @@
 [ExamplePatientProfile2]: StructureDefinition-example-patient-2.html
 [ExampleCapabilityStatementOauth]: CapabilityStatement-ExampleCapabilityStatementOauth.html
 [ExampleCapabilityStatementSMART]: CapabilityStatement-ExampleCapabilityStatementSMART.html
+[ExampleObservationProfile]: StructureDefinition-ExampleObservationProfile.html
 [example-patient-instance]: Patient-example-patient-instance.html
 [ExampleOperationModeOperationDefinition]: OperationDefinition-ExampleOperationModeOperationDefinition.html
 [ExampleQueryOperationDefinition]: OperationDefinition-ExampleQueryOperationDefinition.html

--- a/example-artifacts/fsh-generated/resources/CapabilityStatement-ExampleCapabilityStatementSMART.json
+++ b/example-artifacts/fsh-generated/resources/CapabilityStatement-ExampleCapabilityStatementSMART.json
@@ -229,6 +229,17 @@
               "code": "vread"
             }
           ]
+        },
+        {
+          "type": "Observation",
+          "supportedProfile": [
+            "https://example.com/StructureDefinition/ExampleObservationProfile"
+          ],
+          "interaction": [
+            {
+              "code": "read"
+            }
+          ]
         }
       ]
     }

--- a/example-artifacts/fsh-generated/resources/ImplementationGuide-example.json
+++ b/example-artifacts/fsh-generated/resources/ImplementationGuide-example.json
@@ -72,6 +72,13 @@
       },
       {
         "reference": {
+          "reference": "StructureDefinition/ExampleObservationProfile"
+        },
+        "name": "ExampleObservationProfile",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "Patient/example-patient-instance"
         },
         "name": "ExamplePatientInstance",

--- a/example-artifacts/fsh-generated/resources/StructureDefinition-ExampleObservationProfile.json
+++ b/example-artifacts/fsh-generated/resources/StructureDefinition-ExampleObservationProfile.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "ExampleObservationProfile",
+  "url": "https://example.com/StructureDefinition/ExampleObservationProfile",
+  "name": "ExampleObservationProfile",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.effective[x]",
+        "path": "Observation.effective[x]",
+        "min": 1
+      }
+    ]
+  }
+}

--- a/example-artifacts/input/fsh/ExampleCapabilityStatementSMART.fsh
+++ b/example-artifacts/input/fsh/ExampleCapabilityStatementSMART.fsh
@@ -97,3 +97,8 @@ Usage: #definition
 * rest.resource[=].supportedProfile[+] = Canonical(ExampleEncounterProfile)
 * rest.resource[=].interaction[+].code = #read
 * rest.resource[=].interaction[+].code = #vread
+
+// Observation resource
+* rest.resource[+].type = #Observation
+* rest.resource[=].supportedProfile[+] = Canonical(ExampleObservationProfile)
+* rest.resource[=].interaction[+].code = #read

--- a/example-artifacts/input/fsh/ExampleObservation.fsh
+++ b/example-artifacts/input/fsh/ExampleObservation.fsh
@@ -1,0 +1,4 @@
+Profile: ExampleObservationProfile
+Parent: Observation
+
+* effective[x] 1..1

--- a/src/oas/profiles.js
+++ b/src/oas/profiles.js
@@ -92,7 +92,10 @@ const applyStructureDefinitionChanges = (schema, structureDefinition) => {
     // if a minimum cardinality is set, add the property to the `required` array
     if (element.min && element.min > 0) {
       currentSchema.required = currentSchema.required || [];
-      if (!currentSchema.required.includes(lastPart) && !element.path.includes('[x]')) {
+      if (
+        !currentSchema.required.includes(lastPart) &&
+        !element.path.includes('[x]')
+      ) {
         currentSchema.required.push(lastPart);
       }
 

--- a/src/oas/profiles.js
+++ b/src/oas/profiles.js
@@ -92,7 +92,7 @@ const applyStructureDefinitionChanges = (schema, structureDefinition) => {
     // if a minimum cardinality is set, add the property to the `required` array
     if (element.min && element.min > 0) {
       currentSchema.required = currentSchema.required || [];
-      if (!currentSchema.required.includes(lastPart)) {
+      if (!currentSchema.required.includes(lastPart) && !element.path.includes('[x]')) {
         currentSchema.required.push(lastPart);
       }
 

--- a/test/structuredefinitions.test.js
+++ b/test/structuredefinitions.test.js
@@ -26,6 +26,20 @@ describe('FHIR StructureDefinition to OpenAPI features', () => {
       expect(schema.required).toContain('gender');
     });
 
+    test('A StructureDefinition differential with effective[x] should not be marked as required in the OpenAPI schema', async () => {
+      const sd = getStuctureDefinition(
+        {
+          id: 'Observation.effective[x]',
+          path: 'Observation.effective[x]',
+          min: 1,
+        },
+        'Observation'
+      );
+
+      const schema = applyStructureDefinitionChanges(baseSchema, sd);
+      expect(schema.required).toEqual(['resourceType']);
+    });
+
     test('A StructureDefinition differential with min and max should reflected in the OpenAPI schema', async () => {
       const sd = getStuctureDefinition(
         {


### PR DESCRIPTION
For profiles mandating a field with varying keys is mandatory, e.g. `effective[x]` it is difficult to add these as a required field in the schema. For this, this is removed